### PR TITLE
🔨 Refactor : 기존 userService클래스 삭제 -> 인터페이스, 트랜잭션, 리드온리 클래스 추가 / 예외처리,mapper사용 x 

### DIFF
--- a/server/src/main/java/com/cv/domain/cv/service/CvService.java
+++ b/server/src/main/java/com/cv/domain/cv/service/CvService.java
@@ -21,12 +21,14 @@ import com.cv.domain.project.repository.ProjectRepository;
 import com.cv.domain.project.repository.ProjectSkillStackRepository;
 import com.cv.domain.skillStack.entity.SkillStack;
 import com.cv.domain.skillStack.repository.SkillStackRepository;
-import com.cv.domain.user.service.UserService;
+import com.cv.domain.user.service.ReadOnlyUserService;
 import com.cv.global.exception.BusinessLogicException;
 import com.cv.global.exception.ExceptionCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,7 +45,7 @@ public class CvService {
     private final SkillStackRepository skillStackRepository;
     private final CareerSkillStackRepository careerSkillStackRepository;
     private final ProjectSkillStackRepository projectSkillStackRepository;
-    private final UserService userService;
+    private final ReadOnlyUserService readOnlyUserService;
     private final EducationRepository educationRepository;
     private final ProjectRepository projectRepository;
     private final CustomSectionRepository customSectionRepository;
@@ -54,7 +56,7 @@ public class CvService {
 
     public Cv createCv(Cv cv){
 
-        userService.findUser(cv.getUser().getUserId());
+        readOnlyUserService.findUser(cv.getUser().getUserId());
         return cvRepository.save(cv);
     }
     
@@ -131,8 +133,9 @@ public class CvService {
         }
     }
 
-    public Page<Cv> findLatestCvsByUser(Long userId, Pageable pageable) {
-        return cvRepository.findByUserIdFromRecently(userId, pageable); // (2)
+    public Page<Cv> findLatestCvsByUser(Long userId, int page) {
+        Pageable pageable = PageRequest.of(page -1, 3, Sort.by("createdAt").descending());
+        return cvRepository.findByUserIdFromRecently(userId, pageable);
     }
     
     public void injectLowDomain(Cv cv){

--- a/server/src/main/java/com/cv/domain/user/controller/UserController.java
+++ b/server/src/main/java/com/cv/domain/user/controller/UserController.java
@@ -7,8 +7,8 @@ import com.cv.domain.cv.service.CvService;
 import com.cv.domain.user.dto.MailDto;
 import com.cv.domain.user.dto.UserDto;
 import com.cv.domain.user.entity.User;
-import com.cv.domain.user.mapper.UserMapper;
-import com.cv.domain.user.service.UserService;
+import com.cv.domain.user.service.DefaultUserService;
+import com.cv.domain.user.service.ReadOnlyUserService;
 import com.cv.global.exception.BusinessLogicException;
 import com.cv.global.exception.ExceptionCode;
 import lombok.RequiredArgsConstructor;
@@ -37,111 +37,85 @@ import java.util.Map;
 @CrossOrigin(origins = "*")
 @RequiredArgsConstructor
 public class UserController {
-    private final UserService userService;
-    private final UserMapper mapper;
+    private final DefaultUserService defaultUserService;
+    private final ReadOnlyUserService readOnlyUserService;
     private final CvService cvService;
 
     // 회원등록
     @PostMapping
-    public ResponseEntity postUser(@Valid @RequestBody UserDto.Post userPostDto){
-        User createdUser = userService.createUser(mapper.userPostDtoToUser(userPostDto));
-        return new ResponseEntity(mapper.userPostToSignUpResponse(createdUser), HttpStatus.CREATED);
+    public ResponseEntity createUser(@Valid @RequestBody UserDto.Post userPostDto) {
+        UserDto.SignUpResponse createdUser = defaultUserService.createUser(userPostDto);
+        return new ResponseEntity<>(createdUser, HttpStatus.CREATED);
     }
 
-    // 비밀번호 변경 //user파싸드? user트랜잭셔널 클래스를 만들어서 하나의 @트랜잭셔널만 사용할 수 있도록 서비스로직을 분류하는 게 좋음, 업데이트 서비스랑 리드온리 서비스를 만들어라
-    // 레이어가 추가될 필요는 있음
-    @PatchMapping("/mypage/password/{userId}")
+    // 비밀번호 변경
+    @PatchMapping("/my-page/password/{userId}")
     @PreAuthorize("#userId == authentication.principal.userId")
-    public LocalDateTime passwordPatch(Authentication authentication,
-                                       @PathVariable("userId") @Positive Long userId,
-                                       @Valid @RequestBody UserDto.PasswordPatch userPasswordPatchDto){
-
-        User loggedInUser = (User) authentication.getPrincipal();
-
-        String currentPassword = userPasswordPatchDto.getCurrentPassword();
-        String newPassword = userPasswordPatchDto.getNewPassword();
-        User user = userService.findUser(userId); //(1) 1과2가 하나의 트랜잭션 안에서 동작할 수 있도록 해야함
-        userService.changePassword(loggedInUser, user, currentPassword, newPassword); //(2)
-        return user.getModifiedAt();
+    public LocalDateTime changePassword(Authentication authentication,
+                                        @PathVariable("userId") @Positive Long userId,
+                                        @Valid @RequestBody UserDto.PasswordPatch userPasswordPatchDto) {
+        return defaultUserService.changePassword(userId, userPasswordPatchDto);
     }
 
     // 이름, 휴대번호 변경
-    @PatchMapping("/mypage/{userId}")
+    @PatchMapping("/my-page/{userId}")
     @PreAuthorize("#userId == authentication.principal.userId")
-    public ResponseEntity patchUser(@PathVariable("userId") @Positive Long userId,
-                                    @Valid @RequestBody UserDto.Patch userPatchDto,
-                                    Authentication authentication){
-
-        User user = mapper.userPatchDtoToUser(userPatchDto); //TODO 리팩토링 : (멘토링)user객체로 변환할 이유가 없음
-        user.setUserId(userId);
-        User updatedUser = userService.updateUser(user);
-        return new ResponseEntity(mapper.userPatchToResponse(updatedUser), HttpStatus.OK);
+    public ResponseEntity updateUser(@PathVariable("userId") @Positive Long userId,
+                                     @Valid @RequestBody UserDto.Patch userInfoPatchDto) {
+        UserDto.UserPatchResponse updatedUser = defaultUserService.updateUserInfo(userId, userInfoPatchDto);
+        return new ResponseEntity<>(updatedUser, HttpStatus.OK);
     }
 
     // 계정삭제
-    @DeleteMapping("/mypage/{userId}")
+    @DeleteMapping("/my-page/{userId}")
     @PreAuthorize("#userId == authentication.principal.userId")
-    public ResponseEntity deleteUser(@PathVariable("userId") @Positive Long userId,
-                                     Authentication authentication){
-
-        userService.deleteUser(userId);
-        return new ResponseEntity(HttpStatus.NO_CONTENT);
+    public ResponseEntity deleteUser(@PathVariable("userId") @Positive Long userId) {
+        defaultUserService.deleteUser(userId);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
     // 마이페이지 조회
-    @GetMapping("/mypage/{userId}")
+    @GetMapping("/my-page/{userId}")
     @PreAuthorize("#userId == authentication.principal.userId")
-    public ResponseEntity myPage(@PathVariable("userId") @Positive Long userId,
-                                 @RequestParam(name = "page", defaultValue = "1") int page,
-                                 Authentication authentication){
-
-        User foundUser = userService.findUser(userId);
-
-        Pageable pageable = PageRequest.of(page -1, 3, Sort.by("createdAt").descending());
-        Page<Cv> cvPage = cvService.findLatestCvsByUser(userId, pageable); //해당 유저의 최신 이력서 3개씩 페이지네이션 된 목록을 가져옴
+    public ResponseEntity<Map<String, Object>> getUserProfile(@PathVariable("userId") @Positive Long userId,
+                                                              @RequestParam(name = "page", defaultValue = "1") int page) {
+        User user = readOnlyUserService.findUser(userId);
+        Page<Cv> cvPage = cvService.findLatestCvsByUser(userId, page);
         PageLatestCvDto latestCvDto = new PageLatestCvDto(cvPage);
 
         Map<String, Object> result = new HashMap<>();
-        result.put("profileImage", foundUser.getProfileImage());
-        result.put("name", foundUser.getName());
-        result.put("email",foundUser.getEmail());
-        result.put("phone", foundUser.getPhone());
-        result.put("cvs",latestCvDto);
+        result.put("profileImage", user.getProfileImage());
+        result.put("name", user.getName());
+        result.put("email", user.getEmail());
+        result.put("phone", user.getPhone());
+        result.put("cvs", latestCvDto);
 
         return ResponseEntity.ok(result);
     }
 
     // 이력서 페이지네이션
-    @GetMapping("/mypage/{userId}/cvs")
+    @GetMapping("/my-page/{userId}/cvs")
     @PreAuthorize("#userId == authentication.principal.userId")
-    public ResponseEntity<?> getLatestCvsByUser(@PathVariable Long userId,
-                                                @RequestParam(name = "page", defaultValue = "1") int page) {
-        Pageable pageable = PageRequest.of(page -1, 3, Sort.by("createdAt").descending());
-        Page<Cv> cvPage = cvService.findLatestCvsByUser(userId, pageable);
+    public ResponseEntity<PageLatestCvDto> getLatestCvsByUser(@PathVariable("userId") Long userId,
+                                                              @RequestParam(name = "page", defaultValue = "1") int page) {
+        Page<Cv> cvPage = cvService.findLatestCvsByUser(userId, page);
         PageLatestCvDto latestCvDto = new PageLatestCvDto(cvPage);
         return ResponseEntity.ok(latestCvDto);
     }
 
     // 프로필이미지 등록
-    @PostMapping("/mypage/{userId}/profile-image")
+    @PostMapping("/my-page/{userId}/profile-image")
     @PreAuthorize("#userId == authentication.principal.userId")
-    public ResponseEntity uploadProfileImage(@PathVariable Long userId,
-                                            @RequestBody UserDto.ProfileImage profileImageDto,
-                                            Authentication authentication) {
-        User user = userService.findUser(userId);
-//        user.setUserId(userId);
-
-        String imagePath = profileImageDto.getProfileImage();
-        User updatedUser = userService.uploadProfile(user,imagePath);
-        return new ResponseEntity(mapper.userPatchToResponse(updatedUser), HttpStatus.OK);
+    public ResponseEntity<UserDto.UserPatchResponse> uploadProfileImage(@PathVariable("userId") Long userId,
+                                                   @RequestBody UserDto.ProfileImage profileImageDto) {
+        UserDto.UserPatchResponse updatedUser = defaultUserService.uploadProfile(userId, profileImageDto);
+        return new ResponseEntity<>(updatedUser, HttpStatus.OK);
     }
 
     // 비밀번호 찾기
     @PostMapping("/forgot-password")
-    public ResponseEntity postUser(@RequestBody UserDto.PasswordGet passwordGet){
-        MailDto mailDto = userService.createMailAndChangePassword(passwordGet.getEmail());
-        userService.sendMail(mailDto);
-
+    public ResponseEntity<?> forgotPassword(@RequestBody UserDto.PasswordGet passwordGet) {
+        defaultUserService.createMailAndChangePassword(passwordGet.getEmail());
         return ResponseEntity.ok().build();
     }
 }

--- a/server/src/main/java/com/cv/domain/user/entity/User.java
+++ b/server/src/main/java/com/cv/domain/user/entity/User.java
@@ -71,13 +71,4 @@ public class User extends Auditable {
         if(user.getUserStatus() == UserStatus.USER_WITHDRAWN)
             throw new BusinessLogicException(ExceptionCode.USER_NOT_FOUND);
     }
-
-
-    // 회원정보를 수정,삭제요청 하는 user가 Id로 자신인지 확인
-    public static boolean isMyself(long authenticatedUserId,Long userId) {
-        if(userId != authenticatedUserId){
-            throw new BusinessLogicException(ExceptionCode.USER_NO_HAVE_AUTHORIZATION);
-        }
-        return true;
-    }
 }

--- a/server/src/main/java/com/cv/domain/user/service/DefaultUserService.java
+++ b/server/src/main/java/com/cv/domain/user/service/DefaultUserService.java
@@ -1,9 +1,9 @@
 package com.cv.domain.user.service;
 
-import javax.transaction.Transactional;
-
 import com.cv.domain.user.dto.MailDto;
+import com.cv.domain.user.dto.UserDto;
 import com.cv.domain.user.entity.User;
+import com.cv.domain.user.mapper.UserMapper;
 import com.cv.domain.user.repository.UserRepository;
 import com.cv.global.exception.BusinessLogicException;
 import com.cv.global.exception.ExceptionCode;
@@ -14,92 +14,92 @@ import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.security.SecureRandom;
+import java.time.LocalDateTime;
 import java.util.List;
+
 
 @RequiredArgsConstructor
 @Service
 @Transactional
-public class UserService {
+public class DefaultUserService implements UserServiceInter{
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final UserAuthorityUtils authorityUtils;
     private final JavaMailSender javaMailSender;
+    private final UserMapper mapper;
+    private final ReadOnlyUserService readOnlyUserService;
+
     @Value("${spring.mail.username}")
     private String adminEmail;
 
-    public User createUser(User user) {
+    // 회원등록
+    @Override
+    public UserDto.SignUpResponse createUser(UserDto.Post userPostDto) {
+        User user = mapper.userPostDtoToUser(userPostDto);
         String encryptedPassword = passwordEncoder.encode(user.getPassword());
         user.setPassword(encryptedPassword);
         List<String> roles = authorityUtils.createRoles(user.getEmail());
         user.setRoles(roles);
-        return userRepository.save(user);
+        User createdUser = userRepository.save(user);
+        return mapper.userPostToSignUpResponse(createdUser);
     }
 
+    // 비밀번호 변경
+    @Override
+    public LocalDateTime changePassword(Long userId, UserDto.PasswordPatch userPasswordPatchDto) {
+        User loggedInUser = readOnlyUserService.findUser(userId);
 
-    //password 변경
-    public void changePassword(User loggedInUser, User user, String currentPassword, String newPassword) {
-        user.checkActiveUser(user);
-        User.isMyself(loggedInUser.getUserId(),user.getUserId());
+        String currentPassword = userPasswordPatchDto.getCurrentPassword();
+        String newPassword = userPasswordPatchDto.getNewPassword();
 
+        loggedInUser.checkActiveUser(loggedInUser);
         String loggedInUserPassword = loggedInUser.getPassword();
 
-        if (passwordEncoder.matches(currentPassword,loggedInUserPassword)) {
-            user.setPassword(passwordEncoder.encode(newPassword));
-            userRepository.save(user);
+        if (passwordEncoder.matches(currentPassword, loggedInUserPassword)) {
+            loggedInUser.setPassword(passwordEncoder.encode(newPassword));
+            userRepository.save(loggedInUser);
         } else {
-            throw new IllegalArgumentException("현재 비밀번호가 일치하지 않습니다.");
+            throw new BusinessLogicException(ExceptionCode.PASSWORD_MISMATCH);
         }
+        return loggedInUser.getModifiedAt();
     }
 
 
-    // repository에 userId를 통해 user객체 return
+    // userId가 db에 있는지 확인
+    @Override
     public User findUser(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessLogicException(ExceptionCode.USER_NOT_FOUND));
     }
 
+    // 회원의 기본정보(이름,휴대번호변경) 변경
+    @Override
+    public UserDto.UserPatchResponse updateUserInfo(Long userId, UserDto.Patch userInfoPatchDto) {
+        User loggedInUser = readOnlyUserService.findUser(userId);
+        loggedInUser.checkActiveUser(loggedInUser);
 
-    // 이름, 휴대번호변경하는 로직
-    public User updateUser(User user) {
-        user.checkActiveUser(user);
-        User foundUser = findUser(user.getUserId());
-
-        foundUser.setName(user.getName());
-        foundUser.setPhone(user.getPhone());
-
-        return userRepository.save(foundUser);
+        if(!userInfoPatchDto.getName().equals(loggedInUser.getName())){ loggedInUser.setName(userInfoPatchDto.getName());}
+        if(!userInfoPatchDto.getPhone().equals(loggedInUser.getPhone())){loggedInUser.setPhone(userInfoPatchDto.getPhone());}
+        User updatedUserInfo = userRepository.save(loggedInUser);
+        return mapper.userPatchToResponse(updatedUserInfo);
     }
 
-    // 멤버의 활동상태를 회원탈퇴 상태로 변경
+    // 회원의 활동상태를 탈퇴 상태로 변경
+    @Override
     public void deleteUser(Long userId) {
-        User foundUser = findUser(userId);
-        foundUser.checkActiveUser(foundUser);
-        foundUser.setUserStatus(User.UserStatus.USER_WITHDRAWN);
-        foundUser.setDelete(true);
-        userRepository.save(foundUser);
+        User loggedInUser = readOnlyUserService.findUser(userId);
+        loggedInUser.checkActiveUser(loggedInUser);
+        loggedInUser.setUserStatus(User.UserStatus.USER_WITHDRAWN);
+        loggedInUser.setDelete(true);
+        userRepository.save(loggedInUser);
     }
-
-    // 이메일로 user찾기
-    public User findUserByEmail(String email) {
-        User foundUser = userRepository.findByEmail(email);
-        if (foundUser == null) {
-            throw new BusinessLogicException(ExceptionCode.USER_NOT_FOUND);
-        }
-        return foundUser;
-    }
-
-
-//    public void verifyUserEmail(String email, Long userId) {
-//        User logginUser = findUserByEmail(email);
-//        if (!logginUser.getUserId().equals(userId)) {
-//            throw new BusinessLogicException(ExceptionCode.USER_NO_HAVE_AUTHORIZATION);
-//        }
-//    }
 
     // 비밀번호 찾기
-    public MailDto createMailAndChangePassword(String userEmail) {
+    @Override
+    public void createMailAndChangePassword(String userEmail) {
         String tempPassword = getTempPassword();
         MailDto mailDto = new MailDto();
         mailDto.setAddress(userEmail);
@@ -111,13 +111,13 @@ public class UserService {
                 "로그인 후에는 새로운 비밀번호로 변경하셔야 합니다."
                 + System.lineSeparator() +
                 "감사합니다.");
-
         updatedPassword(tempPassword, userEmail);
-
-        return mailDto;
+        sendMail(mailDto);
     }
 
+
     // 임시비밀번호 발급 이메일 보내기
+    @Override
     public void sendMail(MailDto mailDto) {
         SimpleMailMessage message = new SimpleMailMessage();
         message.setTo(mailDto.getAddress());
@@ -126,6 +126,16 @@ public class UserService {
         message.setFrom(adminEmail);
         message.setReplyTo(adminEmail);
         javaMailSender.send(message);
+    }
+
+    // 이미지 경로 저장하기
+    @Override
+    public UserDto.UserPatchResponse uploadProfile(Long userId, UserDto.ProfileImage profileImageDto) {
+        User loggedInUser = readOnlyUserService.findUser(userId);
+        loggedInUser.checkActiveUser(loggedInUser);
+        loggedInUser.setProfileImage(profileImageDto.getProfileImage());
+        userRepository.save(loggedInUser);
+        return mapper.userPatchToResponse(loggedInUser);
     }
 
     // 현재 DB에 있는 사용자의 비밀번호 -> 임시 비밀번호로 업데이트
@@ -160,15 +170,6 @@ public class UserService {
         for (int i = 0; i < remainingLength; i++) {
             passwordBuilder.append(character.charAt(random.nextInt(character.length())));
         }
-
         return passwordBuilder.toString();
     }
-
-    // 이미지 경로 저장하기
-    public User uploadProfile(User user,String profileImage) {
-        user.setProfileImage(profileImage);
-        return userRepository.save(user);
-    }
 }
-
-

--- a/server/src/main/java/com/cv/domain/user/service/ReadOnlyUserService.java
+++ b/server/src/main/java/com/cv/domain/user/service/ReadOnlyUserService.java
@@ -1,0 +1,61 @@
+package com.cv.domain.user.service;
+
+import com.cv.domain.user.dto.MailDto;
+import com.cv.domain.user.dto.UserDto;
+import com.cv.domain.user.entity.User;
+import com.cv.domain.user.repository.UserRepository;
+import com.cv.global.exception.BusinessLogicException;
+import com.cv.global.exception.ExceptionCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class ReadOnlyUserService implements UserServiceInter {
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDto.SignUpResponse createUser(UserDto.Post userPostDto) {
+        throw new UnsupportedOperationException("This method is not supported in read-only mode.");
+    }
+
+    @Override
+    public LocalDateTime changePassword(Long userId, UserDto.PasswordPatch userPasswordPatchDto) {
+        throw new UnsupportedOperationException("This method is not supported in read-only mode.");
+    }
+
+    // userId가 db에 있는지 확인
+    @Override
+    public User findUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.USER_NOT_FOUND));
+    }
+    @Override
+    public UserDto.UserPatchResponse updateUserInfo(Long userId, UserDto.Patch userInfoPatchDto) {
+        throw new UnsupportedOperationException("This method is not supported in read-only mode.");
+    }
+
+    @Override
+    public void deleteUser(Long userId) {
+        throw new UnsupportedOperationException("This method is not supported in read-only mode.");
+    }
+
+    @Override
+    public void createMailAndChangePassword(String userEmail) {
+        throw new UnsupportedOperationException("This method is not supported in read-only mode.");
+    }
+
+    @Override
+    public void sendMail(MailDto mailDto) {
+        throw new UnsupportedOperationException("This method is not supported in read-only mode.");
+    }
+
+    @Override
+    public  UserDto.UserPatchResponse uploadProfile(Long userId, UserDto.ProfileImage profileImageDto) {
+        throw new UnsupportedOperationException("This method is not supported in read-only mode.");
+    }
+}

--- a/server/src/main/java/com/cv/domain/user/service/UserServiceInter.java
+++ b/server/src/main/java/com/cv/domain/user/service/UserServiceInter.java
@@ -1,0 +1,18 @@
+package com.cv.domain.user.service;
+
+import com.cv.domain.user.dto.MailDto;
+import com.cv.domain.user.dto.UserDto;
+import com.cv.domain.user.entity.User;
+
+import java.time.LocalDateTime;
+
+public interface UserServiceInter {
+    UserDto.SignUpResponse createUser(UserDto.Post userPostDto);
+    LocalDateTime changePassword(Long userId, UserDto.PasswordPatch userPasswordPatchDto);
+    User findUser(Long userId);
+    UserDto.UserPatchResponse updateUserInfo(Long userId, UserDto.Patch userInfoPatchDto);
+    void deleteUser(Long userId);
+    void createMailAndChangePassword(String userEmail);
+    void sendMail(MailDto mailDto);
+    UserDto.UserPatchResponse uploadProfile(Long userId, UserDto.ProfileImage profileImageDto);
+}

--- a/server/src/main/java/com/cv/global/auth/oauth2/handler/OAuth2UserSuccessHandler.java
+++ b/server/src/main/java/com/cv/global/auth/oauth2/handler/OAuth2UserSuccessHandler.java
@@ -2,7 +2,6 @@ package com.cv.global.auth.oauth2.handler;
 
 import com.cv.domain.user.entity.User;
 import com.cv.domain.user.repository.UserRepository;
-import com.cv.domain.user.service.UserService;
 import com.cv.global.auth.jwt.tokenizer.JwtTokenizer;
 import com.cv.global.auth.utils.UserAuthorityUtils;
 import lombok.RequiredArgsConstructor;

--- a/server/src/main/java/com/cv/global/config/SecurityConfiguration.java
+++ b/server/src/main/java/com/cv/global/config/SecurityConfiguration.java
@@ -1,6 +1,5 @@
 package com.cv.global.config;
 
-import com.cv.domain.user.service.UserService;
 import com.cv.global.auth.jwt.filter.JwtAuthenticationFilter;
 import com.cv.global.auth.jwt.filter.JwtVerificationFilter;
 import com.cv.global.auth.jwt.handler.UserAccessDeniedHandler;

--- a/server/src/main/java/com/cv/global/exception/ExceptionCode.java
+++ b/server/src/main/java/com/cv/global/exception/ExceptionCode.java
@@ -16,7 +16,8 @@ public enum ExceptionCode {
     SKILL_STACK_NOT_FOUND(404, "Skill stack not found"),
     RESUME_EXISTS(409, "Resume exists"),
     USER_NO_HAVE_AUTHORIZATION(404, "User no have authoization"),
-    NOT_IMPLEMENTATION(501, "Not Implementation");
+    NOT_IMPLEMENTATION(501, "Not Implementation"),
+    PASSWORD_MISMATCH(401,"Password mismatch" );
 
 
     @Getter


### PR DESCRIPTION
- 서비스클래스를 하나의 인터페이스를 두고 그 밑에 트랜잭셔널, 리드온리로 나누는 작업
- controller클래스에서 mapper를 사용하지 않고 dto를 서비스계층으로 전해서 서비스계층해서 dto정보를 사용한 뒤 repository에 저장할 때만 최종적으로 엔티티객체로 변환시켜 저장하는작업 코드 리펙토링함